### PR TITLE
Use correct aws types

### DIFF
--- a/typings/dynamodb/dynamodb-delete-item-input.d.ts
+++ b/typings/dynamodb/dynamodb-delete-item-input.d.ts
@@ -1,3 +1,3 @@
-import {DeleteItemInput} from 'aws-sdk/clients/dynamodb';
+import {DocumentClient} from 'aws-sdk/lib/dynamodb/document_client';
 
-export declare type DynamoDBDeleteItemInput = Omit<DeleteItemInput, 'TableName' | 'ReturnValues'>;
+export declare type DynamoDBDeleteItemInput = Omit<DocumentClient.DeleteItemInput, 'TableName' | 'ReturnValues'>;

--- a/typings/dynamodb/dynamodb-get-item-input.d.ts
+++ b/typings/dynamodb/dynamodb-get-item-input.d.ts
@@ -1,3 +1,3 @@
-import {GetItemInput} from 'aws-sdk/clients/dynamodb';
+import {DocumentClient} from 'aws-sdk/lib/dynamodb/document_client';
 
-export declare type DynamoDBGetItemInput = Omit<GetItemInput, 'TableName'>;
+export declare type DynamoDBGetItemInput = Omit<DocumentClient.GetItemInput, 'TableName'>;

--- a/typings/dynamodb/dynamodb-insert-item-input.d.ts
+++ b/typings/dynamodb/dynamodb-insert-item-input.d.ts
@@ -1,3 +1,3 @@
-import {PutItemInput} from 'aws-sdk/clients/dynamodb';
+import {DocumentClient} from 'aws-sdk/lib/dynamodb/document_client';
 
-export declare type DynamoDBInsertItemInput = Omit<PutItemInput, 'TableName' | 'Item' | 'ConditionExpression'>;
+export declare type DynamoDBInsertItemInput = Omit<DocumentClient.PutItemInput, 'TableName' | 'Item' | 'ConditionExpression'>;

--- a/typings/dynamodb/dynamodb-overwrite-item-input.d.ts
+++ b/typings/dynamodb/dynamodb-overwrite-item-input.d.ts
@@ -1,3 +1,3 @@
-import {PutItemInput} from 'aws-sdk/clients/dynamodb';
+import {DocumentClient} from 'aws-sdk/lib/dynamodb/document_client';
 
-export type DynamoDBOverwriteItemInput = Omit<PutItemInput, 'TableName' | 'Item'>;
+export type DynamoDBOverwriteItemInput = Omit<DocumentClient.PutItemInput, 'TableName' | 'Item'>;

--- a/typings/dynamodb/dynamodb-query-item-input.d.ts
+++ b/typings/dynamodb/dynamodb-query-item-input.d.ts
@@ -1,3 +1,3 @@
-import {QueryInput} from 'aws-sdk/clients/dynamodb';
+import {DocumentClient} from 'aws-sdk/lib/dynamodb/document_client';
 
-export declare type DynamoDBQueryItemInput = Omit<QueryInput, 'TableName'>;
+export declare type DynamoDBQueryItemInput = Omit<DocumentClient.QueryInput, 'TableName'>;

--- a/typings/dynamodb/dynamodb-scan-item-input.d.ts
+++ b/typings/dynamodb/dynamodb-scan-item-input.d.ts
@@ -1,3 +1,3 @@
-import {ScanInput} from 'aws-sdk/clients/dynamodb';
+import {DocumentClient} from 'aws-sdk/lib/dynamodb/document_client';
 
-export declare type DynamoDBScanItemInput = Omit<ScanInput, 'TableName'> & { unique_identifier?: string };
+export declare type DynamoDBScanItemInput = Omit<DocumentClient.ScanInput, 'TableName'> & { unique_identifier?: string };


### PR DESCRIPTION
For types `DynamoDBDeleteItemInput`, `DynamoDBGetItemInput`, `DynamoDBInsertItemInput`, `DynamoDBOverwriteItemInput`, `DynamoDBQueryItemInput` and `DynamoDBScanItemInput`,  the bindings to the corresponding aws types have been changed