### PR TITLE
GHXAPI-554: poc transactWriteItems

### DIFF
--- a/src/dynamodb.js
+++ b/src/dynamodb.js
@@ -42,6 +42,10 @@ class DynamodbAdapter {
         }
     }
 
+    async runTransactWriteItems(transactionItems) {
+        return this._dynamodb.transactWrite({TransactItems: transactionItems}).promise();
+    }
+
     async batchOverwrite(params) {
         const items = await this._prepareBatchOverwriteQuery(params);
         const batch = 25;


### PR DESCRIPTION
the DTA package does not support TransactWriteItems functionality. Without it, it is a lot harder to maintain consistency when multiple items need to be created, deleted, etc.; all at the same time and maybe with on differents tables and when these records absolutely need to be created without any errors.

With transactions, if 2 or more records are meant to be created (deleted, etc.) and something fails in one or more of them, the whole transaction is reverted to ensure consistency (and the dev can retry the whole action without worrying about what records were created and which were not).

Without transactions, maybe a record failed to be created and all other related records that depend on the failed one are created, which leads to inconsistency issues on the data and bad/unhandled states on the application. 